### PR TITLE
Formatted output to be in discord ansi code block

### DIFF
--- a/src/main/java/io/github/_4drian3d/vconsolelinker/manager/WebHookManager.java
+++ b/src/main/java/io/github/_4drian3d/vconsolelinker/manager/WebHookManager.java
@@ -32,7 +32,10 @@ public final class WebHookManager {
             while ((log = logQueue.poll()) != null) {
                 builder.append('\n').append(log);
             }
-            client.sendWebHook(WebHook.builder().content(builder.toString()).build());
+            String WebHookOutput = "```ansi\n" + builder.toString() + "\n```";
+            if (!WebHookOutput.equals("```ansi\n\n```")) {
+                client.sendWebHook(WebHook.builder().content(WebHookOutput).build());
+            }
         }, 0, 1, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
This addresses the issue where sometimes the console sends ansi output to discord without the proper code block, this modified plugin should take the output and encase it in the discord code block for ansi code, which makes it look cleaner compared to seeing "[0m" everywhere